### PR TITLE
Using 'archive.php' is deprecated; also added nice

### DIFF
--- a/debian/conf/piwik-archive
+++ b/debian/conf/piwik-archive
@@ -6,4 +6,4 @@
 # | |	| | .------ day of week (0 - 6) (Sunday=0 or 7) OR sun,mon,tue,wed,thu,fri,sat
 # | |	| | |
 # * *	* * *	user-name       command to be executed
-# 5 *	* * *	www-data        [ -e /usr/share/piwik/misc/cron/archive.php ] && [ -x /usr/bin/php ] && /usr/bin/php /usr/share/piwik/misc/cron/archive.php -- "url=http://example.org/piwik/" >/dev/null 2>&1
+# 5 *	* * *	www-data        [ -e /usr/share/piwik/console ] && [ -x /usr/bin/php ] && nice /usr/bin/php /usr/share/piwik/console core:archive --url="http://example.org/piwik/" > /dev/null 2>&1 


### PR DESCRIPTION
Original archive cron job caused the following error message:
```
Using this 'archive.php' script is no longer recommended.
Please use '/path/to/php /usr/share/piwik/console core:archive --url=https://piwik.XXX.org/piwik' instead.
To get help use '/path/to/php /usr/share/piwik/console core:archive --help'
See also: http://piwik.org/docs/setup-auto-archiving/
```

This pull request fixes see issue.

It also adds `nice` for this background task.
