### PR TITLE
Optimize Composer autoloader for release

### DIFF
--- a/scripts/build-package.sh
+++ b/scripts/build-package.sh
@@ -100,7 +100,7 @@ function organizePackage() {
 	then
 		curl -sS https://getcomposer.org/installer | php
 	fi
-	php composer.phar install --no-dev
+	php composer.phar install --no-dev -o
 	rm -rf composer.phar
 	rm -rf vendor/twig/twig/test/
 	rm -rf vendor/twig/twig/doc/


### PR DESCRIPTION
`-o` makes Composer [optimize the autoloader](https://getcomposer.org/doc/03-cli.md#install)

@mattab: where is the release script? I guess it should be modified also but I wasn't able to find the repository.