### PR TITLE
Package tecnick.com/tcpdf is abandoned

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ fixperms:
 		@chmod 0755 $(DESTDIR)/usr/share/piwik/misc/composer/build-xhprof.sh
 		@chmod 0755 $(DESTDIR)/usr/share/piwik/misc/composer/clean-xhprof.sh
 		@chmod 0755 $(DESTDIR)/usr/share/piwik/vendor/pear/archive_tar/sync-php4
-		@chmod 0755 $(DESTDIR)/usr/share/piwik/vendor/tecnick.com/tcpdf/tools/tcpdf_addfont.php
+		@chmod 0755 $(DESTDIR)/usr/share/piwik/vendor/tecnickcom/tcpdf/tools/tcpdf_addfont.php
 		@echo "done."
 
 # check lintian licenses so we can remove obsolete ones

--- a/debian/piwik.lintian-overrides
+++ b/debian/piwik.lintian-overrides
@@ -41,7 +41,7 @@ piwik: extra-license-file usr/share/piwik/vendor/psr/log/LICENSE
 piwik: extra-license-file usr/share/piwik/vendor/symfony/console/Symfony/Component/Console/LICENSE
 piwik: extra-license-file usr/share/piwik/vendor/symfony/event-dispatcher/Symfony/Component/EventDispatcher/LICENSE
 piwik: extra-license-file usr/share/piwik/vendor/symfony/monolog-bridge/Symfony/Bridge/Monolog/LICENSE
-piwik: extra-license-file usr/share/piwik/vendor/tecnick.com/tcpdf/LICENSE.TXT
+piwik: extra-license-file usr/share/piwik/vendor/tecnickcom/tcpdf/LICENSE.TXT
 piwik: extra-license-file usr/share/piwik/vendor/tedivm/jshrink/LICENSE
 piwik: extra-license-file usr/share/piwik/vendor/twig/twig/LICENSE
 piwik: privacy-breach-piwik usr/share/piwik/js/piwik.js

--- a/scripts/build-package.sh
+++ b/scripts/build-package.sh
@@ -115,33 +115,33 @@ function organizePackage() {
 	rm -rf vendor/mnapoli/php-di/website
 	rm -rf vendor/mnapoli/php-di/news
 	rm -rf vendor/mnapoli/php-di/doc
-	rm -rf vendor/tecnick.com/tcpdf/examples
-	rm -rf vendor/tecnick.com/tcpdf/CHANGELOG.txt
+	rm -rf vendor/tecnickcom/tcpdf/examples
+	rm -rf vendor/tecnickcom/tcpdf/CHANGELOG.txt
 	rm -rf vendor/guzzle/guzzle/docs/
 
 	# Delete un-used fonts
-    rm -rf vendor/tecnick.com/tcpdf/fonts/ae_fonts_2.0
-    rm -rf vendor/tecnick.com/tcpdf/fonts/dejavu-fonts-ttf-2.33
-    rm -rf vendor/tecnick.com/tcpdf/fonts/dejavu-fonts-ttf-2.34
-    rm -rf vendor/tecnick.com/tcpdf/fonts/freefont-20100919
-    rm -rf vendor/tecnick.com/tcpdf/fonts/freefont-20120503
-    rm -rf vendor/tecnick.com/tcpdf/fonts/freemon*
-    rm -rf vendor/tecnick.com/tcpdf/fonts/cid*
-    rm -rf vendor/tecnick.com/tcpdf/fonts/courier*
-    rm -rf vendor/tecnick.com/tcpdf/fonts/aefurat*
-    rm -rf vendor/tecnick.com/tcpdf/fonts/dejavusansb*
-    rm -rf vendor/tecnick.com/tcpdf/fonts/dejavusansi*
-    rm -rf vendor/tecnick.com/tcpdf/fonts/dejavusansmono*
-    rm -rf vendor/tecnick.com/tcpdf/fonts/dejavusanscondensed*
-    rm -rf vendor/tecnick.com/tcpdf/fonts/dejavusansextralight*
-    rm -rf vendor/tecnick.com/tcpdf/fonts/dejavuserif*
-    rm -rf vendor/tecnick.com/tcpdf/fonts/freesansi*
-    rm -rf vendor/tecnick.com/tcpdf/fonts/freesansb*
-    rm -rf vendor/tecnick.com/tcpdf/fonts/freeserifb*
-    rm -rf vendor/tecnick.com/tcpdf/fonts/freeserifi*
-    rm -rf vendor/tecnick.com/tcpdf/fonts/pdf*
-    rm -rf vendor/tecnick.com/tcpdf/fonts/times*
-    rm -rf vendor/tecnick.com/tcpdf/fonts/uni2cid*
+    rm -rf vendor/tecnickcom/tcpdf/fonts/ae_fonts_2.0
+    rm -rf vendor/tecnickcom/tcpdf/fonts/dejavu-fonts-ttf-2.33
+    rm -rf vendor/tecnickcom/tcpdf/fonts/dejavu-fonts-ttf-2.34
+    rm -rf vendor/tecnickcom/tcpdf/fonts/freefont-20100919
+    rm -rf vendor/tecnickcom/tcpdf/fonts/freefont-20120503
+    rm -rf vendor/tecnickcom/tcpdf/fonts/freemon*
+    rm -rf vendor/tecnickcom/tcpdf/fonts/cid*
+    rm -rf vendor/tecnickcom/tcpdf/fonts/courier*
+    rm -rf vendor/tecnickcom/tcpdf/fonts/aefurat*
+    rm -rf vendor/tecnickcom/tcpdf/fonts/dejavusansb*
+    rm -rf vendor/tecnickcom/tcpdf/fonts/dejavusansi*
+    rm -rf vendor/tecnickcom/tcpdf/fonts/dejavusansmono*
+    rm -rf vendor/tecnickcom/tcpdf/fonts/dejavusanscondensed*
+    rm -rf vendor/tecnickcom/tcpdf/fonts/dejavusansextralight*
+    rm -rf vendor/tecnickcom/tcpdf/fonts/dejavuserif*
+    rm -rf vendor/tecnickcom/tcpdf/fonts/freesansi*
+    rm -rf vendor/tecnickcom/tcpdf/fonts/freesansb*
+    rm -rf vendor/tecnickcom/tcpdf/fonts/freeserifb*
+    rm -rf vendor/tecnickcom/tcpdf/fonts/freeserifi*
+    rm -rf vendor/tecnickcom/tcpdf/fonts/pdf*
+    rm -rf vendor/tecnickcom/tcpdf/fonts/times*
+    rm -rf vendor/tecnickcom/tcpdf/fonts/uni2cid*
 
 	# ------------
 	# WARNING: Did you read the WARNING above?


### PR DESCRIPTION
refs piwik/piwik#9095 In https://github.com/piwik/piwik/pull/9101 we change the package from `tecnick.com` to `tecnickcom`