### PR TITLE
Fixes to release piwik 2.16.0 as debian package

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+piwik (2.16.0-1) stable; urgency=high
+
+  * Releasing Piwik 2.16.0
+
+ -- Michael Gebetsroither <mgebetsroither@mgit.at>  Thu, 25 Feb 2016 17:12:48 +0100
+
 piwik (2.15.0-1) stable; urgency=high
 
   * Releasing Piwik 2.15.0

--- a/debian/install
+++ b/debian/install
@@ -5,6 +5,7 @@ piwik/config/global.ini.php			etc/piwik/
 piwik/config/manifest.inc.php			etc/piwik/
 piwik/config/environment/dev.php		etc/piwik/environment/
 piwik/config/environment/test.php		etc/piwik/environment/
+piwik/config/environment/ui-test.php		etc/piwik/environment/
 piwik/console					usr/share/piwik/
 piwik/core					usr/share/piwik/
 piwik/index.php					usr/share/piwik/

--- a/debian/piwik.lintian-overrides
+++ b/debian/piwik.lintian-overrides
@@ -19,7 +19,6 @@ piwik: extra-license-file usr/share/piwik/libs/jqplot/gpl-2.0.txt
 piwik: extra-license-file usr/share/piwik/libs/jquery/gpl-2.0.txt
 piwik: extra-license-file usr/share/piwik/libs/jquery/gpl-3.0.txt
 piwik: extra-license-file usr/share/piwik/libs/pChart/GPLv3.txt
-piwik: extra-license-file usr/share/piwik/libs/PiwikTracker/LICENSE
 piwik: extra-license-file usr/share/piwik/libs/sparkline/gpl-2.0.txt
 piwik: extra-license-file usr/share/piwik/libs/Zend/LICENSE.txt
 piwik: extra-license-file usr/share/piwik/misc/gpl-3.0.txt


### PR DESCRIPTION
Minimal fixes to build piwik 2.16.0 as debian package.