### PR TITLE
Apache2 patch

### DIFF
--- a/debian/conf/apache.conf
+++ b/debian/conf/apache.conf
@@ -1,5 +1,5 @@
 # if you are running apache, the file should already be linked
-# in /etc/apache2/conf.d
+# in /etc/apache2/conf.d or /etc/apache2/conf-available
 
 # Uncomment the "Alias" to add piwik as a global alias
 # or if you are running virtual hosts, then add the alias

--- a/debian/piwik.postinst
+++ b/debian/piwik.postinst
@@ -78,6 +78,18 @@ else
 	echo "Lighttpd not installed, skipping"
 fi
 
+if [ -d "/etc/apache2/conf-available" ]
+then
+	if [ ! -e /etc/apache2/conf-available/piwik.conf ];
+	then
+		ln -s /etc/piwik/apache.conf /etc/apache2/conf-available/piwik.conf
+		ln -s /etc/apache2/conf-available/piwik.conf /etc/apache2/conf-enabled/piwik.conf
+		invoke-rc.d apache2 reload 2>/dev/null || true
+	fi
+	echo "  * Check Piwik web configuration in /etc/apache2/conf-available/piwik.conf"
+else
+	echo "Apache2.4 not installed, skipping"
+fi
 
 if [ -d "/etc/apache2/conf.d" ]
 then

--- a/debian/piwik.postinst
+++ b/debian/piwik.postinst
@@ -83,7 +83,7 @@ then
 	if [ ! -e /etc/apache2/conf-available/piwik.conf ];
 	then
 		ln -s /etc/piwik/apache.conf /etc/apache2/conf-available/piwik.conf
-		ln -s /etc/apache2/conf-available/piwik.conf /etc/apache2/conf-enabled/piwik.conf
+		a2enconf --maintmode piwik
 		invoke-rc.d apache2 reload 2>/dev/null || true
 	fi
 	echo "  * Check Piwik web configuration in /etc/apache2/conf-available/piwik.conf"

--- a/debian/piwik.postrm
+++ b/debian/piwik.postrm
@@ -20,11 +20,11 @@ then
 	
 	if [ -L /etc/apache2/conf-available/piwik.conf ];
 	then
-		rm -f /etc/apache2/conf-available/piwik.conf
 		if [ -L /etc/apache2/conf-enabled/piwik.conf ];
 		then
-			rm -f /etc/apache2/conf-enabled/piwik.conf
-		fi
+			a2disconf --maintmode piwik
+		fi			
+		rm -f /etc/apache2/conf-available/piwik.conf
 		invoke-rc.d apache2 reload 3>/dev/null || true
 	fi			
 fi

--- a/debian/piwik.postrm
+++ b/debian/piwik.postrm
@@ -25,7 +25,8 @@ then
 		then
 			rm -f /etc/apache2/conf-enabled/piwik.conf
 		fi
-		invoke-rc.d apache2 reload 3>/dev/null || true			
+		invoke-rc.d apache2 reload 3>/dev/null || true
+	fi			
 fi
 
 #DEBHELPER#

--- a/debian/piwik.postrm
+++ b/debian/piwik.postrm
@@ -17,6 +17,15 @@ then
 		rm -f /etc/apache2/conf.d/piwik.conf
 		invoke-rc.d apache2 reload 3>/dev/null || true
 	fi
+	
+	if [ -L /etc/apache2/conf-available/piwik.conf ];
+	then
+		rm -f /etc/apache2/conf-available/piwik.conf
+		if [ -L /etc/apache2/conf-enabled/piwik.conf ];
+		then
+			rm -f /etc/apache2/conf-enabled/piwik.conf
+		fi
+		invoke-rc.d apache2 reload 3>/dev/null || true			
 fi
 
 #DEBHELPER#


### PR DESCRIPTION
Patches following:

`piwik.postinst` & `piwik.rminst`
Inserts logic to deal with Debian 8+ `/etc/apache2/conf-available` configuration location

`conf/apache.conf`
References `/etc/apache2/conf-available` in header comments