### PR TITLE
remove php file from piwik-icons

### DIFF
--- a/scripts/build-package.sh
+++ b/scripts/build-package.sh
@@ -156,6 +156,7 @@ function organizePackage() {
 	rm -rf plugins/Morpheus/icons/*.lock
 	rm -rf plugins/Morpheus/icons/*.svg
 	rm -rf plugins/Morpheus/icons/*.txt
+	rm -rf plugins/Morpheus/icons/*.php
 
 	# Delete un-used fonts
 	rm -rf vendor/tecnickcom/tcpdf/fonts/ae_fonts_2.0


### PR DESCRIPTION
fixes https://travis-ci.org/piwik/piwik-icons/builds/305670939

I have added a test to check if all devices/os/brands from DeviceDetector have an icon, so this file needs to be deleted on build to avoid future issues.